### PR TITLE
FD II: non-unifrom grids and LinearSolve.jl 

### DIFF
--- a/MT1D_response.jl
+++ b/MT1D_response.jl
@@ -1,11 +1,11 @@
-"""
+#=
 This function computes the magnetotelluric (MT) response given resistivity and thickness vectors.
 The implementation is based on the equations from the book:
 Ward, S. H., & Hohmann, G. W. (1988). Electromagnetic Theory for Geophysical Applications. In M. N. Nabighian (Ed.), 
 Electromagnetic Methods in Applied Geophysics, Volume 1: Theory. Society of Exploration Geophysicists.
 
-Author: Pankaj K Mishra (pankaj.mishra@gtk.fi)
-Date: 2025-02-10
+Author: pankajkmishra 
+Last Edit: 2025-02-21
 
 
 # Arguments
@@ -16,7 +16,8 @@ Date: 2025-02-10
 # Returns
 - `ρa`: Apparent resistivity (Ω·m)
 - `φ`: Phase (degrees)
-"""
+=#
+
 function MT1D_response(frequencies, resistivities, thicknesses)
     μ0 = 4π * 1e-7  # Free-space permeability (H/m) (Ward and Hohmann, 1988, Eq. 3.96)
     m = length(resistivities)          

--- a/MT1D_response_FD.jl
+++ b/MT1D_response_FD.jl
@@ -1,4 +1,4 @@
-"""
+#=
 This function computes the magnetotelluric (MT) response given resistivity and thickness vectors.
 The implementation is based on Finite-difference method 
 
@@ -17,10 +17,9 @@ Date: 2025-02-14
 - `ρa`: Apparent resistivity (Ω·m)
 - `φ`: Phase (degrees) 
 
-TODO: compute default dz and z_max based on the input resistivities and thicknesses 
-TODO: replace solver to LinearSolve.jl for better performance 
+=# 
 
-"""	
+
 function MT1D_response_FD(frequencies, resistivities, thicknesses; dz=5.0, z_max=6000.0)
     μ0 = 4π * 1e-7
     ω = 2π .* frequencies

--- a/MT1D_response_FD_II.jl
+++ b/MT1D_response_FD_II.jl
@@ -1,0 +1,112 @@
+#=
+Computes the magnetotelluric (MT) response using a finite-difference method with a non-uniform grid.
+
+This function calculates the MT response based on provided resistivity and thickness vectors. Unlike the earlier MT1D_response_FD.jl implementation that used a uniform grid, this version employs a non-uniform grid—where the spacing increases with depth—and uses LinearSolve.jl to solve the resulting linear system.
+
+Author: Pankaj K Mishra
+Date: 2025-02-21
+
+# What goes in 
+- frequencies: Vector of frequencies (Hz)
+- resistivities: Vector of resistivities (Ω·m)
+- thicknesses: Vector of layer thicknesses (m)
+- dz: (Optional) Initial grid spacing (m)
+- z_max: (Optional) Maximum depth (m)
+- z_scale: (Optional) Scaling factor for increasing grid spacing default is 1.05 
+
+# What comes out 
+- ρa: Apparent resistivity (Ω·m)
+- φ: Phase (degrees)
+
+=# 
+
+using LinearSolve
+
+function MT1D_response_FD_II(frequencies, resistivities, thicknesses; dz=nothing, z_max=nothing, z_scale=1.05)
+    μ0 = 4π * 1e-7
+   
+    if dz === nothing
+        f_max = maximum(frequencies)
+        skin_depth_top = sqrt(2 * resistivities[1] / (2π * f_max * μ0))
+        resolution_factor = 20.0
+        dz = skin_depth_top / resolution_factor
+    end
+    if z_max === nothing
+        z_max = 100000.0
+    end
+
+  
+    z = [0.0]
+    current_dz = dz
+    while z[end] < z_max
+        push!(z, z[end] + current_dz)
+        current_dz *= z_scale
+    end
+
+    # Precompute conductivity based on the depth grid
+    N = length(z)
+    sigma = zeros(ComplexF64, N)
+    z_boundary1 = thicknesses[1]
+    z_boundary2 = thicknesses[1] + thicknesses[2]
+    for (i, z_val) in enumerate(z)
+        if z_val < z_boundary1
+            sigma[i] = 1 / resistivities[1]
+        elseif z_val < z_boundary2
+            sigma[i] = 1 / resistivities[2]
+        else
+            sigma[i] = 1 / resistivities[3]
+        end
+    end
+
+    ω = 2π .* frequencies
+    Z = Vector{ComplexF64}(undef, length(frequencies))
+
+    # Frequency loop (Does it help to parallelize this loop?, maybe not for 1D)
+    for (j, f_val) in enumerate(frequencies)
+        ω_val = 2π * f_val
+        k2 = -1im * ω_val * μ0 .* sigma
+        n_unknowns = N - 1
+        A = zeros(ComplexF64, n_unknowns, n_unknowns)
+        b = zeros(ComplexF64, n_unknowns)
+        if N >= 3
+            h1 = z[2] - z[1]
+            h2 = z[3] - z[2]
+            A[1,1] = -2/(h1*h2) + k2[2]
+            if n_unknowns > 1
+                A[1,2] = 2/(h2*(h1+h2))
+            end
+            b[1] = -2/(h1*(h1+h2))
+            for i in 3:(N-1)
+                j_idx = i - 1
+                h_previous = z[i] - z[i-1]
+                h_next = z[i+1] - z[i]
+                A[j_idx, j_idx-1] = 2/(h_previous*(h_previous+h_next))
+                A[j_idx, j_idx]   = -2/(h_previous*h_next) + k2[i]
+                A[j_idx, j_idx+1] = 2/(h_next*(h_previous+h_next))
+            end
+        else
+            h = z[2] - z[1]
+            A[1,1] = 1/h + 1im*sqrt(-1im*ω_val*μ0*(1/resistivities[end]))
+            b[1] = -1/h
+        end
+        h_last = z[end] - z[end-1]
+        sigma_bottom = 1 / resistivities[end]
+        k_bottom = sqrt(-1im * ω_val * μ0 * sigma_bottom)
+        A[end, end-1] = -1/h_last
+        A[end, end]   = 1/h_last + 1im*k_bottom
+        b[end] = 0.0
+        prob = LinearProblem(A, b)
+        # LinearSolve.jl can do many cool things here. diferent solvers!
+        sol = solve(prob)
+        U = sol.u
+        E = ComplexF64[1.0]
+        append!(E, U)
+        h0 = z[2] - z[1]
+        dE_dz0 = (E[2] - E[1]) / h0
+        Z[j] = -1im * ω_val * μ0 * E[1] / dE_dz0
+    end
+
+    ρa = abs.(Z).^2 ./ (ω .* μ0)
+    φ = atan.(imag.(Z), real.(Z)) .* (180/π)
+    return ρa, φ
+end

--- a/MT1D_test.jl
+++ b/MT1D_test.jl
@@ -1,20 +1,34 @@
-using Plots
-include("MT1D_response.jl")  ;
-include("MT1D_response_FD.jl") ;
+#=
+This script tests all 1D MT forward solvers for accuracy 
+I should include something for performance comparison but for 
+1D MT all of them seems to be fast enough. We cross that bridge when we come to it 
 
-ρ = [100.0, 10.0, 100.0] ;
-h = [2000.0, 1000.0] ;     
+Author: Pankaj K Mishra
+Date: 2025-02-21
+
+=#
+
+using Plots
+include("MT1D_response.jl");
+include("MT1D_response_FD.jl");
+include("MT1D_response_FD_II.jl");
+
+
+ρ = [100.0, 10.0, 100.0];
+h = [2000.0, 1000.0];
 f = 10 .^ range(-3, 2, length=100);
 
 
 ρa_ana, φ_ana = MT1D_response(f, ρ, h);
-ρa_fd, φ_fd   = MT1D_response_FD(f, ρ, h; dz=5.0, z_max=6000.0);
+ρa_fd, φ_fd = MT1D_response_FD(f, ρ, h; dz=5.0, z_max=6000.0); 
+ρa_fdn, φ_fdn = MT1D_response_FD_II(f, ρ, h, dz=5.0, z_max=160000.0, z_scale=1.05); 
 
 
 p1 = plot(f, ρa_ana, xscale=:log10, yscale=:log10, linewidth=2, xflip=true,
     xlabel="Frequency (Hz)", ylabel="Apparent Resistivity (Ω·m)",
     title="Apparent Resistivity", label="Analytical");
-plot!(p1, f, ρa_fd, linestyle=:dash, linewidth=2, label="FD");
+plot!(p1, f, ρa_fd, linestyle=:dash, linewidth=2, label="FD winform grid");
+plot!(p1, f, ρa_fdn, linestyle=:dot, linewidth=2, label="FD non-uniform grid");
 xlims!(p1, 10^-3, 10^2);
 ylims!(p1, 1, 1000);
 
@@ -22,8 +36,10 @@ ylims!(p1, 1, 1000);
 p2 = plot(f, φ_ana, xscale=:log10, linewidth=2, xflip=true,
     xlabel="Frequency (Hz)", ylabel="Phase (degrees)",
     title="Phase", label="Analytical");
-plot!(p2, f, φ_fd, linestyle=:dash, linewidth=2, label="FD");
+plot!(p2, f, φ_fd, linestyle=:dash, linewidth=2, label="FD winform grid");
+plot!(p2, f, φ_fdn, linestyle=:dot, linewidth=2, label="FD non-uniform grid");
 xlims!(p2, 10^-3, 10^2);
 ylims!(p2, 0, 90);
 
-plot(p1, p2, layout=(2, 1), size=(800,600)) 
+
+plot(p1, p2, layout=(2, 1), size=(800,600))


### PR DESCRIPTION
Updates:
- Added a new function to solve the 1D magnetotelluric (MT) forward problem using a non-uniform grid with finite differences - (FD). I believe this approach is more efficient.
- The forward solver II now accepts dz, z_max, and z_scale as inputs, with default values provided.
- Removed docstring comments for now and reverted to the standard commenting style.
- The new FD solver II now utilizes LinearSolve.jl, aligning more closely with the SciML ecosystem.