### PR TITLE
bathymetry, topography, adaptive RBF points, adaptive RBF kernel scaling, experimental distortion treatment 

### DIFF
--- a/examples/make_mesh_modem.jl
+++ b/examples/make_mesh_modem.jl
@@ -20,7 +20,7 @@ GLMakie.activate!()
 
 #----- user controls (edit here) -----
 const MODE            = length(ARGS) >= 6 ? lowercase(ARGS[6]) : lowercase(get(ENV, "MTGEO_MESH_MODE", "gui"))
-const DATA_PATH       = length(ARGS) >= 1 ? ARGS[1] : normpath(@__DIR__, "MT3DINV4", "data5pc.dat")
+const DATA_PATH       = length(ARGS) >= 1 ? ARGS[1] : normpath(@__DIR__, "MT3DINV4", "data7O10Dg.dat")
 const OUT_PATH        = length(ARGS) >= 2 ? ARGS[2] : joinpath(dirname(DATA_PATH), "mesh_start_model.rho")
 const DEFAULT_TOPO_PATH = normpath(@__DIR__, "MT3DINV4", "ArcticDEM_30m_EPSG26918.tif")
 const TOPO_PATH       = length(ARGS) >= 3 ? ARGS[3] : (isfile(DEFAULT_TOPO_PATH) ? DEFAULT_TOPO_PATH : "")
@@ -49,9 +49,23 @@ const USE_TOPO        = !isempty(strip(TOPO_PATH))
 
 const TOPO_CACHE = Ref{Any}(nothing)
 
+# modem's covariance reader skips exactly 16 header lines - keep this 16 lines long
 const COV_HEADER = """
 +-----------------------------------------------------------------------------+
-| This file defines model covariance . See ModEM documentation for details. |
+| This file defines model covariance for a recursive autoregression scheme.   |
+| The model space may be divided into distinct areas using integer masks.     |
+| Mask 0 is reserved for air; mask 9 is reserved for ocean. Smoothing between |
+| air, ocean and the rest of the model is turned off automatically. You can   |
+| also define exceptions to override smoothing between any two model areas.   |
+| To turn off smoothing set it to zero. This header is 16 lines long.         |
+| 1. Grid dimensions excluding air layers (Nx, Ny, NzEarth)                   |
+| 2. Smoothing in the X direction (NzEarth real values)                       |
+| 3. Smoothing in the Y direction (NzEarth real values)                       |
+| 4. Vertical smoothing (1 real value)                                        |
+| 5. Number of times the smoothing should be applied (1 integer >= 0)         |
+| 6. Number of exceptions (1 integer >= 0)                                    |
+| 7. Exceptions in the form e.g. 2 3 0. (to turn off smoothing between 2 & 3) |
+| 8. Two integer layer indices and Nx x Ny block of masks, repeated as needed.|
 +-----------------------------------------------------------------------------+
 """
 
@@ -483,6 +497,180 @@ function write_covariance_file(path::AbstractString, mask::Array{<:Integer, 3};
     return path
 end
 
+function _earth_only_z_edges(m)
+    z0 = m.origin[3] + sum(m.dz[1:m.nz_air])
+    return z0 .+ vcat(0.0, cumsum(m.dz[(m.nz_air + 1):end]))
+end
+
+function _site_column_constraints(m, d)
+    cols = Dict{Tuple{Int, Int}, Tuple{String, Float64}}()
+    for isite in 1:d.ns
+        ix = clamp(searchsortedlast(m.x_edges, d.x[isite]), 1, m.nx)
+        iy = clamp(searchsortedlast(m.y_edges, d.y[isite]), 1, m.ny)
+        key = (ix, iy)
+        site_z = Float64(d.z[isite])
+        current = get(cols, key, ("", Inf))
+        if site_z < current[2]
+            cols[key] = (String(d.site[isite]), site_z)
+        end
+    end
+    return cols
+end
+
+function _apply_site_surface_constraints(m, d, surface_local)
+    surface_local === nothing && return nothing, (
+        nadjusted = 0,
+        adjustments = NamedTuple[],
+        impossible = NamedTuple[],
+        text = "Covariance follows topography only.",
+    )
+
+    earth_z_edges = _earth_only_z_edges(m)
+    earth_z_centers = Float64.(m.z_centers[(m.nz_air + 1):end])
+    adjusted = copy(surface_local)
+    adjustments = NamedTuple[]
+    impossible = NamedTuple[]
+
+    for ((ix, iy), (site_name, site_z)) in _site_column_constraints(m, d)
+        max_first = searchsortedlast(earth_z_edges, site_z)
+        if max_first < 1
+            push!(impossible, (
+                site = site_name,
+                ix = ix,
+                iy = iy,
+                site_z = site_z,
+                top_edge = Float64(earth_z_edges[1]),
+                clearance = site_z - Float64(earth_z_edges[1]),
+            ))
+            continue
+        end
+
+        desired_first = min(max_first, m.nz_earth)
+        old_surface = Float64(adjusted[ix, iy])
+        new_surface = min(old_surface, earth_z_centers[desired_first])
+        adjusted[ix, iy] = new_surface
+
+        if new_surface < old_surface - 1e-9
+            push!(adjustments, (
+                site = site_name,
+                ix = ix,
+                iy = iy,
+                site_z = site_z,
+                surface_from = old_surface,
+                surface_to = new_surface,
+                lift = old_surface - new_surface,
+            ))
+        end
+    end
+
+    sort!(adjustments; by = row -> -row.lift)
+    sort!(impossible; by = row -> row.clearance)
+    text = isempty(adjustments) ?
+        "Covariance follows topography only." :
+        @sprintf("Covariance auto-adjusted in %d station column(s) to honour site elevations.", length(adjustments))
+
+    return adjusted, (
+        nadjusted = length(adjustments),
+        adjustments = adjustments,
+        impossible = impossible,
+        text = text,
+    )
+end
+
+function _site_air_report(m, d)
+    earth_z_edges = _earth_only_z_edges(m)
+    bad = NamedTuple[]
+
+    for isite in 1:d.ns
+        ix = clamp(searchsortedlast(m.x_edges, d.x[isite]), 1, m.nx)
+        iy = clamp(searchsortedlast(m.y_edges, d.y[isite]), 1, m.ny)
+        first_earth = findfirst(!=(0), vec(m.cov_mask[ix, iy, :]))
+        first_earth === nothing && error("No earth cells remain in covariance column for site $(d.site[isite]) at mesh column ($ix, $iy).")
+
+        top_edge = earth_z_edges[first_earth]
+        clearance = Float64(d.z[isite]) - Float64(top_edge)
+        if clearance < 0.0
+            push!(bad, (
+                site = String(d.site[isite]),
+                ix = ix,
+                iy = iy,
+                site_z = Float64(d.z[isite]),
+                top_edge = Float64(top_edge),
+                clearance = clearance,
+            ))
+        end
+    end
+
+    sort!(bad; by = row -> row.clearance)
+    nbad = length(bad)
+    ok = nbad == 0
+    sample_rows = bad[1:min(end, 5)]
+    sample = isempty(sample_rows) ? "" : join([
+        @sprintf("%s needs %.1f m", row.site, -row.clearance) for row in sample_rows
+    ], ", ")
+    max_raise = isempty(bad) ? 0.0 : -bad[1].clearance
+    summary = ok ?
+        @sprintf("✓ All %d sites lie at or below the first non-air covariance cell.", d.ns) :
+        @sprintf("• %d site(s) lie in air relative to the written covariance mask. Raise the local model surface at those XY columns until the top of the first non-air cell is at or above each site Z. Example adjustments: %s.",
+            nbad, sample)
+    fix = ok ? "" :
+        "Fix the model, not the data: remove leading air-mask 0 values in the flagged covariance columns and raise the matching topography/model surface until every flagged site has nonnegative clearance (site_z - top_of_first_earth >= 0)."
+
+    return (
+        ok = ok,
+        nbad = nbad,
+        rows = bad,
+        sample = sample,
+        max_raise = max_raise,
+        text = summary,
+        fix = fix,
+    )
+end
+
+function _print_site_surface_report(m)
+    if m.site_surface.nadjusted > 0
+        println(m.site_surface.text)
+        for row in m.site_surface.adjustments[1:min(end, 10)]
+            println(@sprintf(
+                "  %s: xcell=%d ycell=%d surface %.3f -> %.3f (lift %.3f m)",
+                row.site, row.ix, row.iy, row.surface_from, row.surface_to, row.lift))
+        end
+        if m.site_surface.nadjusted > 10
+            println(@sprintf("  ... %d more adjusted column(s) omitted.", m.site_surface.nadjusted - 10))
+        end
+    end
+
+    if !isempty(m.site_surface.impossible)
+        @warn(@sprintf("%d site(s) still sit above the shallowest earth cell; revise the vertical mesh or topography datum.", length(m.site_surface.impossible)))
+        for row in m.site_surface.impossible[1:min(end, 10)]
+            println(@sprintf(
+                "  %s: xcell=%d ycell=%d site_z=%.3f shallowest_earth=%.3f clearance=%.3f",
+                row.site, row.ix, row.iy, row.site_z, row.top_edge, row.clearance))
+        end
+        if length(m.site_surface.impossible) > 10
+            println(@sprintf("  ... %d more impossible site(s) omitted.", length(m.site_surface.impossible) - 10))
+        end
+    end
+    return nothing
+end
+
+function _print_site_air_report(m)
+    m.site_air.ok && return nothing
+
+    @warn(@sprintf("%d site(s) are in air relative to the written covariance mask.", m.site_air.nbad))
+    println(m.site_air.fix)
+    println(@sprintf("Worst-case upward surface adjustment needed: %.1f m.", m.site_air.max_raise))
+    for row in m.site_air.rows[1:min(end, 10)]
+        println(@sprintf(
+            "  %s: xcell=%d ycell=%d site_z=%.3f top_of_first_earth=%.3f clearance=%.3f",
+            row.site, row.ix, row.iy, row.site_z, row.top_edge, row.clearance))
+    end
+    if m.site_air.nbad > 10
+        println(@sprintf("  ... %d more site(s) omitted.", m.site_air.nbad - 10))
+    end
+    return nothing
+end
+
 function build_mesh_bundle(d, sx, sy, Tobs;
                            ρ_bg, dx_core, dy_core, nx_core, ny_core,
                            nx_pad, ny_pad, pad_factor, z_first, z_factor, depth_mult,
@@ -523,17 +711,32 @@ function build_mesh_bundle(d, sx, sy, Tobs;
             air_first = max(5.0, Float64(z_first) / AIR_FIRST_DIV))
     end
 
+    site_surface = (
+        nadjusted = 0,
+        adjustments = NamedTuple[],
+        impossible = NamedTuple[],
+        text = "Covariance follows topography only.",
+    )
+    if surface_local !== nothing
+        surface_local, site_surface = _apply_site_surface_constraints(base, d, surface_local)
+    end
+
     A = _build_resistivity_model(base, surface_local)
     cov_mask = _build_covariance_mask(base, surface_local)
+    site_air = _site_air_report((; base..., A = A, cov_mask = cov_mask), d)
     return (; base..., A = A, cov_mask = cov_mask, cov_value = Float64(cov_value),
               topo_active = surface_local !== nothing,
               topo_name = surface_local === nothing ? "flat" : basename(TOPO_PATH),
-              datum_elev = datum_elev)
+              datum_elev = datum_elev,
+              site_surface = site_surface,
+              site_air = site_air)
 end
 
 function save_outputs(m)
     _write_start_model_ws(OUT_PATH, m; rotation = 0.0)
     write_covariance_file(OUT_COV_PATH, m.cov_mask; cov_x = m.cov_value, cov_y = m.cov_value, cov_z = m.cov_value)
+    _print_site_surface_report(m)
+    _print_site_air_report(m)
     return nothing
 end
 
@@ -569,7 +772,7 @@ if MODE == "nogui"
         nx_pad = N_PAD, ny_pad = N_PAD,
         pad_factor = PAD_FACTOR, z_first = Float64(z_first0), z_factor = VERTICAL_FACTOR,
         depth_mult = DEPTH_MULT, cov_value = COV_VALUE0, topo_ctx = topo_ctx)
-    @printf("grid %d×%d×%d (%d cells); core %d×%d @ %.0f×%.0f m; air %d; max sites/cell %d; occupied %.0f%%; pad %.0f km/side; depth %.0f km; cov %.2f (topography)\n",
+    @printf("grid %d×%d×%d (%d cells); core %d×%d @ %.0f×%.0f m; air %d; max sites/cell %d; occupied %.0f%%; pad %.0f km/side; depth %.0f km; cov %.2f (topography + sites)\n",
         m.nx, m.ny, m.nz, m.nx * m.ny * m.nz, m.nx_core, m.ny_core, m.dx_core, m.dy_core,
         m.nz_air, m.maxper, 100 * m.occupied, m.pad_extent_km, m.depth_km, m.cov_value)
     save_outputs(m)
@@ -592,6 +795,9 @@ function suggestions(m)
         "the boundary should sit at least one skin depth at the longest period (δ(Tmax)) from the core.")
     m.depth_km < m.δmax_km && push!(msgs,
         "• Model is too shallow — increase 'Depth × δ(Tmax)' so the mesh spans the depth of investigation.")
+    !isempty(m.site_surface.impossible) && push!(msgs,
+        "• Some sites still sit above the shallowest available earth cell — reduce the top air thickness or revise the topography/datum so the earth model starts above those site elevations.")
+    m.site_air.ok || push!(msgs, m.site_air.text * " " * m.site_air.fix)
     ok = isempty(msgs)
     text = ok ? "✓ Mesh looks well-sized for ModEM inversion." : join(msgs, "    ")
     return (text = text, ok = ok)
@@ -675,7 +881,7 @@ infotext = join([
     @sprintf("spacing   >  %.1f km", spacing.median / 1000),
     @sprintf("rho(data) >  %.0f ohm-m", ρ_bg_data),
     @sprintf("topo      >  %s", USE_TOPO ? basename(TOPO_PATH) : "off"),
-    @sprintf("cov(mode) >  topography"),
+    @sprintf("cov(mode) >  topography + site elevations"),
     @sprintf("cov(out)  >  %s", basename(OUT_COV_PATH)),
 ], "\n")
 Label(left[1, 1:3], infotext; font = "Consolas", fontsize = 13, halign = :left,
@@ -794,8 +1000,11 @@ function refresh!(m)
     apply_limits!(ax, m)
     s = suggestions(m)
     topo_info = m.topo_active ? @sprintf("topo %s · datum %.1f m · air %d", m.topo_name, m.datum_elev, m.nz_air) : "topo flat"
-    gridinfo = @sprintf("%d × %d × %d cells · core %d × %d (%.0f × %.0f m) · max sites/cell %d · depth %.0f km · cov %.2f (topography) · %s",
-        m.nx, m.ny, m.nz, m.nx_core, m.ny_core, m.dx_core, m.dy_core, m.maxper, m.depth_km, m.cov_value, topo_info)
+    site_info = m.site_air.ok ?
+        (m.site_surface.nadjusted == 0 ? "all sites below surface" : @sprintf("all sites below surface (%d auto-adjusted column(s))", m.site_surface.nadjusted)) :
+        @sprintf("%d site(s) in air", m.site_air.nbad)
+    gridinfo = @sprintf("%d × %d × %d cells · core %d × %d (%.0f × %.0f m) · max sites/cell %d · depth %.0f km · cov %.2f (topography + sites) · %s · %s",
+        m.nx, m.ny, m.nz, m.nx_core, m.ny_core, m.dx_core, m.dy_core, m.maxper, m.depth_km, m.cov_value, topo_info, site_info)
     sug_obs[] = gridinfo * "\n" * s.text
     sug_color[] = s.ok ? RGBf(0.15, 0.5, 0.25) : RGBf(0.75, 0.2, 0.15)
     return nothing
@@ -830,7 +1039,10 @@ end
 on(savebtn.clicks) do _
     m = mesh[]
     save_outputs(m)
-    status[] = @sprintf("Saved %d×%d×%d model → %s | covariance %.2f (topography) → %s", m.nx, m.ny, m.nz, OUT_PATH, m.cov_value, OUT_COV_PATH)
+    air_status = m.site_air.ok ?
+        (m.site_surface.nadjusted == 0 ? "all sites below surface" : @sprintf("all sites below surface after %d auto-adjusted column(s)", m.site_surface.nadjusted)) :
+        @sprintf("WARNING: %d site(s) in air; see guidance above", m.site_air.nbad)
+    status[] = @sprintf("Saved %d×%d×%d model → %s | covariance %.2f (topography + sites) → %s | %s", m.nx, m.ny, m.nz, OUT_PATH, m.cov_value, OUT_COV_PATH, air_status)
     @info status[]
 end
 

--- a/examples/run_vfsa3dmt.jl
+++ b/examples/run_vfsa3dmt.jl
@@ -1,8 +1,4 @@
 # cascadia 3D VFSA MT inversion via MTGeophysics.jl
-# pure vfsa (single trial), schedule calibrated to the observed misfit scale
-# from the jul-13 runs: uphill dE_rms2 median ~0.015, p90 ~0.03, stationary
-# over the whole run. T0=0.05 gives ~75% uphill acceptance at the start,
-# ~50% mid-run, quench near the end — annealing is active throughout.
 # needs the external ModEM forward solver and an MPI runtime (OpenMPI or MPICH)
 
 using MTGeophysics
@@ -29,7 +25,7 @@ cfg = VFSA3DMTConfig(
     log_bounds            = (-0.5, 4.0), # log10(Ω·m) model bounds
     step_scale            = 0.05,       # proposal step = step_scale × bound width 
     max_iter              = 5000,       # iteration cap
-    n_trials              = 4,          # classic vfsa: one proposal, one metropolis test
+    n_trials              = 4,          # greedy best-of-4, deferred metropolis on the winner
     temp_kappa            = 0.05,       # T0 ~ 3x median uphill dE -> ~75% uphill acceptance at start
     cool_ratio            = 0.02,       # T_end = 1e-3: ~50% acceptance mid-run, quench by 5000
     target_rms            = 3.0,        # early-stop only; harmless if never reached
@@ -39,8 +35,12 @@ cfg = VFSA3DMTConfig(
     keep_models           = false,      # discard trial models (this one was added because on CSC supercomputer limited storage)
     keep_dpred            = false,      # discard predicted-data files
     model_save_every      = 100,        # keep the winning trial model every 100 iters
-    sigma_scale           = 2.0,        # RBF width in cells (1σ); larger = smoother
+    sigma_scale           = 2.0,        # RBF width in cells (1σ) at the top of the core
+    sigma_scale_deep      = 2.0,        # RBF width at the bottom; log-depth interpolated
     trunc_sigmas          = 3.0,        # RBF support cutoff in σ
+    ctrl_depth_power      = 0.25,       # mild shallow bias; p>=0.5 starves the deep (ceiling test v5)
+    water_log10           = 0.5,        # freeze start-model cells below this (ocean at -0.523)
+    bathymetry_file       = "",         # "" = derive mask from the start model
 )
 
 best_model, iter_log = VFSA3DMT(start_model; dobs_path=observed_data, cfg=cfg)

--- a/src/Bathymetry3D.jl
+++ b/src/Bathymetry3D.jl
@@ -1,0 +1,99 @@
+# bathymetry extraction and water masks for WS3D models
+# water cells are detected from log10 resistivity below a threshold; the
+# bathymetry file stores water-bottom depth per wet column at physical cell
+# centers, so it can be re-applied to any grid on the same coordinate frame
+
+using Dates
+using Printf
+
+"""
+    extract_bathymetry(m; water_log10) -> (x, y, depth)
+
+Water-bottom depth (m, positive down) per wet column of a WS3D model. A column
+is wet where its surface cells have `log10 ρ < water_log10`; depth is the bottom
+edge of the deepest contiguous water cell. Non-contiguous water below the
+seafloor triggers a warning and is ignored. Returns coordinate vectors of the
+wet cell-center columns and their depths.
+"""
+function extract_bathymetry(m::WS3DModel; water_log10::Float64)
+    zbot = cumsum(m.dz)
+    xs = Float64[]; ys = Float64[]; ds = Float64[]
+    n_stray = 0
+    for j in 1:m.ny, i in 1:m.nx
+        klast = 0
+        for k in 1:m.nz
+            m.A[i, j, k] < water_log10 || break
+            klast = k
+        end
+        n_stray += count(k -> m.A[i, j, k] < water_log10, klast+1:m.nz)
+        if klast > 0
+            push!(xs, m.cx[i]); push!(ys, m.cy[j]); push!(ds, zbot[klast])
+        end
+    end
+    n_stray > 0 && @warn "extract_bathymetry: $n_stray water-like cells below the seafloor ignored"
+    return (x=xs, y=ys, depth=ds)
+end
+
+"""
+    write_bathymetry(path, bathy; water_log10=NaN)
+
+Write a bathymetry table (`x_center_m  y_center_m  water_depth_m`, one row per
+wet column) as produced by [`extract_bathymetry`](@ref).
+"""
+function write_bathymetry(path::AbstractString, bathy; water_log10::Float64=NaN)
+    open(path, "w") do io
+        println(io, "# MTGeophysics bathymetry — ", Dates.format(now(), "yyyy-mm-dd HH:MM:SS"))
+        println(io, "# water_log10=", water_log10, "  n_wet=", length(bathy.depth))
+        println(io, "# x_center_m  y_center_m  water_depth_m")
+        for t in eachindex(bathy.depth)
+            @printf(io, "%15.3f %15.3f %12.3f\n", bathy.x[t], bathy.y[t], bathy.depth[t])
+        end
+    end
+    return path
+end
+
+"""
+    read_bathymetry(path) -> (x, y, depth)
+
+Read a bathymetry table written by [`write_bathymetry`](@ref).
+"""
+function read_bathymetry(path::AbstractString)
+    xs = Float64[]; ys = Float64[]; ds = Float64[]
+    for line in eachline(path)
+        s = strip(line)
+        (isempty(s) || startswith(s, "#")) && continue
+        p = split(s)
+        push!(xs, parse(Float64, p[1]))
+        push!(ys, parse(Float64, p[2]))
+        push!(ds, parse(Float64, p[3]))
+    end
+    return (x=xs, y=ys, depth=ds)
+end
+
+"""
+    water_mask_from_bathymetry(m, bathy) -> BitArray{3}
+
+Full-grid mask of water cells: for each wet column (matched to the nearest
+cell-center column of `m`), cells whose centers lie above the water-bottom
+depth are water.
+"""
+function water_mask_from_bathymetry(m::WS3DModel, bathy)
+    mask = falses(m.nx, m.ny, m.nz)
+    zc = abs.(m.cz)
+    for t in eachindex(bathy.depth)
+        i = argmin(abs.(m.cx .- bathy.x[t]))
+        j = argmin(abs.(m.cy .- bathy.y[t]))
+        for k in 1:m.nz
+            zc[k] < bathy.depth[t] || break
+            mask[i, j, k] = true
+        end
+    end
+    return mask
+end
+
+"""
+    water_mask_from_model(m; water_log10) -> BitArray{3}
+
+Full-grid mask of cells with `log10 ρ < water_log10`.
+"""
+water_mask_from_model(m::WS3DModel; water_log10::Float64) = BitArray(m.A .< water_log10)

--- a/src/Distortion.jl
+++ b/src/Distortion.jl
@@ -1,0 +1,180 @@
+# Per-site galvanic distortion estimation (variable projection).
+# Author: @pankajkmishra
+# Solves a real, frequency-independent 2x2 matrix C per site minimizing the
+# error-weighted misfit Zobs ~ C*Zpred over all periods, damped toward identity,
+# then computes chi2/rms on the distortion-corrected residuals. Tipper is
+# magnetic and is never corrected.
+
+using Printf
+using Dates
+
+struct DistortionFit
+    χ²::Float64
+    rms::Float64
+    penalty::Float64        # damping-weighted ||C-I||^2 summed over sites, diagnostic only
+    C::Array{Float64,3}     # 2 x 2 x ns, [c11 c12; c21 c22] per site
+    site::Vector{String}
+end
+
+#---------- per-site damped least squares ----------
+
+# component pairing for Zobs = C*Zpred with columns 1..4 = XX,XY,YX,YY:
+#   obs col 1 (XX): c_1*Zp[:,1] + c_2*Zp[:,3]     obs col 2 (XY): c_1*Zp[:,2] + c_2*Zp[:,4]
+#   obs col 3 (YX): same coefficients with row 2   obs col 4 (YY): same with row 2
+
+# solve one row of C from obs columns (o1,o2), damped toward the prior (p1,p2)
+# normal equations accumulated in complex arithmetic: Re(a*conj(b)) is the
+# stacked real/imag inner product, so real unknowns come out exact
+function _distortion_row(Zo::AbstractMatrix{ComplexF64}, Zp::AbstractMatrix{ComplexF64},
+                         Ze::AbstractMatrix{ComplexF64},
+                         o1::Int, o2::Int, p1::Float64, p2::Float64, damping::Float64)
+    N11 = 0.0; N12 = 0.0; N22 = 0.0; r1 = 0.0; r2 = 0.0; m = 0
+    @inbounds for i in 1:size(Zo, 1)
+        for (oc, ac, bc) in ((o1, 1, 3), (o2, 2, 4))
+            zo = Zo[i, oc]; a = Zp[i, ac]; b = Zp[i, bc]; ze = Ze[i, oc]
+            if isfinite(real(zo)) && isfinite(imag(zo)) &&
+               isfinite(real(a)) && isfinite(imag(a)) &&
+               isfinite(real(b)) && isfinite(imag(b)) &&
+               isfinite(real(ze)) && isfinite(imag(ze))
+                σ = abs(ze)
+                if σ > 0
+                    w = 1.0 / (σ * σ)
+                    N11 += w * abs2(a)
+                    N12 += w * real(a * conj(b))
+                    N22 += w * abs2(b)
+                    r1  += w * real(zo * conj(a))
+                    r2  += w * real(zo * conj(b))
+                    m   += 1
+                end
+            end
+        end
+    end
+    # relative damping: identity-prior strength as a fixed fraction of the data information
+    λ = damping * 0.5 * (N11 + N22)
+    (m < 2 || !isfinite(λ)) && return p1, p2, λ
+    det = (N11 + λ) * (N22 + λ) - N12 * N12
+    det <= 1e-12 * max(N11, N22, λ, eps())^2 && return p1, p2, λ
+    c1 = ((N22 + λ) * (r1 + λ * p1) - N12 * (r2 + λ * p2)) / det
+    c2 = ((N11 + λ) * (r2 + λ * p2) - N12 * (r1 + λ * p1)) / det
+    (isfinite(c1) && isfinite(c2)) || return p1, p2, λ
+    return c1, c2, λ
+end
+
+# full 2x2 C for one site, rows solved independently; also returns per-row λ
+function solve_site_distortion(Zo::AbstractMatrix{ComplexF64}, Zp::AbstractMatrix{ComplexF64},
+                               Ze::AbstractMatrix{ComplexF64}; damping::Float64)
+    c11, c12, λ1 = _distortion_row(Zo, Zp, Ze, 1, 2, 1.0, 0.0, damping)
+    c21, c22, λ2 = _distortion_row(Zo, Zp, Ze, 3, 4, 0.0, 1.0, damping)
+    return c11, c12, c21, c22, λ1, λ2
+end
+
+#---------- corrected misfit ----------
+
+# corrected residual when both predicted coefficients exist, uncorrected
+# fallback when only the entry's own prediction exists; the datum count N is
+# then identical to _accumulate_chi2! and damping=Inf reproduces chi2_and_rms
+function _accumulate_chi2_distorted!(accχ2::Base.RefValue{Float64}, accN::Base.RefValue{Int},
+                                     accP::Base.RefValue{Float64},
+                                     Zo::AbstractMatrix{ComplexF64}, Zp::AbstractMatrix{ComplexF64},
+                                     Ze::AbstractMatrix{ComplexF64},
+                                     c11::Float64, c12::Float64, c21::Float64, c22::Float64,
+                                     λ1::Float64, λ2::Float64)
+    @inbounds for i in 1:size(Zo, 1)
+        for (oc, ac, bc, c1, c2) in ((1, 1, 3, c11, c12), (2, 2, 4, c11, c12),
+                                     (3, 1, 3, c21, c22), (4, 2, 4, c21, c22))
+            zo = Zo[i, oc]; ze = Ze[i, oc]
+            (isfinite(real(zo)) && isfinite(imag(zo)) &&
+             isfinite(real(ze)) && isfinite(imag(ze))) || continue
+            σ = abs(ze)
+            σ > 0 || continue
+            a = Zp[i, ac]; b = Zp[i, bc]
+            zown = Zp[i, oc]
+            if isfinite(real(a)) && isfinite(imag(a)) && isfinite(real(b)) && isfinite(imag(b))
+                zp = c1 * a + c2 * b
+            elseif isfinite(real(zown)) && isfinite(imag(zown))
+                zp = zown
+            else
+                continue
+            end
+            rre = (real(zp) - real(zo)) / σ
+            rim = (imag(zp) - imag(zo)) / σ
+            accχ2[] += rre * rre + rim * rim
+            accN[]  += 2
+        end
+    end
+    s1 = (c11 - 1.0)^2 + c12^2
+    s2 = c21^2 + (c22 - 1.0)^2
+    s1 > 0 && isfinite(λ1) && (accP[] += λ1 * s1)
+    s2 > 0 && isfinite(λ2) && (accP[] += λ2 * s2)
+    return nothing
+end
+
+"""
+    chi2_and_rms_distorted(dobs_path, dpred_path; damping, use_tipper=true) -> DistortionFit
+
+Distortion-corrected misfit between observed and predicted ModEM data files.
+Per site a real 2x2 matrix `C` minimizing the error-weighted misfit
+`Zobs ~ C*Zpred` over all periods is solved in closed form, damped toward the
+identity with relative strength `damping` (`Inf` forces `C = I` and reproduces
+`chi2_and_rms` exactly). Impedance residuals use `C*Zpred`; tipper residuals
+are never corrected. Returns a `DistortionFit` carrying χ², rms, the damping
+penalty, and the per-site matrices for diagnostics.
+"""
+function chi2_and_rms_distorted(dobs_path::AbstractString, dpred_path::AbstractString;
+                                damping::Float64, use_tipper::Bool=true)
+    dobs  = load_data_modem(dobs_path)
+    dpred = load_data_modem(dpred_path)
+    dobs.site == dpred.site || error("site mismatch between observed and predicted files")
+    length(dobs.T) == length(dpred.T) && all(isapprox.(dobs.T, dpred.T; rtol=1e-8)) ||
+        error("period mismatch between observed and predicted files")
+
+    χ2 = Ref(0.0); N = Ref(0); P = Ref(0.0)
+    ns = dobs.ns
+    C = Array{Float64,3}(undef, 2, 2, ns)
+    for s in 1:ns
+        Zo = view(dobs.Z, :, :, s)
+        Zp = view(dpred.Z, :, :, s)
+        Ze = view(dobs.Zerr, :, :, s)
+        c11, c12, c21, c22, λ1, λ2 = solve_site_distortion(Zo, Zp, Ze; damping=damping)
+        C[1, 1, s] = c11; C[1, 2, s] = c12
+        C[2, 1, s] = c21; C[2, 2, s] = c22
+        _accumulate_chi2_distorted!(χ2, N, P, Zo, Zp, Ze, c11, c12, c21, c22, λ1, λ2)
+    end
+
+    if use_tipper
+        _accumulate_chi2!(χ2, N, dobs.tip, dpred.tip, dobs.tiperr)
+    end
+
+    rms = N[] > 0 ? sqrt(χ2[] / N[]) : NaN
+    return DistortionFit(χ2[], rms, P[], C, copy(dobs.site))
+end
+
+#---------- diagnostics ----------
+
+# per-site distortion table sorted by ||C-I||_F descending, so the most
+# distorted sites top the list; groom-bailey flavored angles, no decomposition
+function write_distortion_file(path::AbstractString, fit::DistortionFit;
+                               iter::Int=-1, rms::Float64=NaN, damping::Float64=NaN)
+    ns = length(fit.site)
+    C = fit.C
+    normci = [sqrt((C[1,1,s]-1.0)^2 + C[1,2,s]^2 + C[2,1,s]^2 + (C[2,2,s]-1.0)^2) for s in 1:ns]
+    order = sortperm(normci; rev=true)
+    open(path, "w") do io
+        println(io, "# per-site galvanic distortion C of the current best model — ",
+                Dates.format(Dates.now(), "yyyy-mm-dd HH:MM:SS"))
+        @printf(io, "# iter=%d  rms=%.5f  penalty=%.5g  damping=%.4g\n", iter, rms, fit.penalty, damping)
+        println(io, "# twist/shear in degrees; sorted by ||C-I||_F descending")
+        @printf(io, "%-12s %9s %9s %9s %9s %9s %9s %9s %9s %9s\n",
+                "# site", "c11", "c12", "c21", "c22", "det", "twist", "shear", "aniso", "normCI")
+        for s in order
+            c11 = C[1,1,s]; c12 = C[1,2,s]; c21 = C[2,1,s]; c22 = C[2,2,s]
+            detc  = c11 * c22 - c12 * c21
+            twist = atand(c21 - c12, c11 + c22)
+            shear = atand(c12 + c21, c11 + c22)
+            aniso = (c11 - c22) / (c11 + c22)
+            @printf(io, "%-12s %9.4f %9.4f %9.4f %9.4f %9.4f %9.3f %9.3f %9.4f %9.4f\n",
+                    fit.site[s], c11, c12, c21, c22, detc, twist, shear, aniso, normci[s])
+        end
+    end
+    return path
+end

--- a/src/MTGeophysics.jl
+++ b/src/MTGeophysics.jl
@@ -16,6 +16,7 @@ using Proj
 include("Data.jl")
 include("Model.jl")
 include("Chi2RMS.jl")
+include("Distortion.jl")
 
 #----- Headless core/padding utilities (always available) ------------------#
 
@@ -28,6 +29,10 @@ include("ShapefileOverlay.jl")
 #----- WS3D format model I/O (log10 internal) -----------------------------#
 
 include("WS3DModel.jl")
+
+#----- Bathymetry extraction and water masks ------------------------------#
+
+include("Bathymetry3D.jl")
 
 #----- Visualization (optional, requires GLMakie) -------------------------#
 
@@ -57,6 +62,7 @@ export Data, Model, ModEMData, ModEMModel
 export load_data_modem, write_data_modem, make_nan_data, calc_rho_pha
 export read_mackie3d_model, load_model_modem, write_model_modem
 export chi2_and_rms
+export chi2_and_rms_distorted, DistortionFit, write_distortion_file
 
 #----- Exports: Core utilities (always available) -------------------------#
 
@@ -72,6 +78,11 @@ export load_shapefile_geometries, prepare_shapefiles
 
 export WS3DModel
 export load_ws3d_model, read_ws3d_model, write_ws3d_model
+
+#----- Exports: Bathymetry / water masks ----------------------------------#
+
+export extract_bathymetry, write_bathymetry, read_bathymetry
+export water_mask_from_bathymetry, water_mask_from_model
 
 #----- Exports: 3-D VFSA inversion ---------------------------------------#
 

--- a/src/VFSA3DMT.jl
+++ b/src/VFSA3DMT.jl
@@ -14,7 +14,17 @@ using Dates
 Configuration for the 3D VFSA MT inversion. All VFSA hyper-parameters,
 file-management switches, and external-solver settings live here. Every field is
 a required keyword with no default — values are supplied by the run script (see
-`examples/run_vfsa3dmt.jl`), so the engine carries no hidden defaults.
+`examples/run_vfsa3dmt.jl`), so the engine carries no hidden defaults. The only
+exceptions are the galvanic-distortion fields `distortion_mode` and
+`distortion_damping`, which are optional and default to the previous behavior
+(no distortion handling), keeping existing run scripts working unchanged.
+
+With `distortion_mode = :full` each misfit evaluation solves, per site, a real
+frequency-independent 2x2 matrix `C` minimizing the error-weighted misfit
+`Zobs ~ C*Zpred` (variable projection, damped toward the identity by
+`distortion_damping`), and anneals on the corrected rms. The per-site matrices
+of the current best model are written to `chain_XX/distortion_best.txt`, sorted
+by distortion severity, identifying which sites are galvanically distorted.
 
 `out_root::String` is the base name/path of the run directory holding the
 per-chain ModEM working folders. A timestamp is appended, so the actual run
@@ -29,6 +39,19 @@ winner (`n_trials = 1` is classic VFSA). One temperature schedule drives both
 proposal width and acceptance, cooling from `temp_kappa` to
 `cool_ratio*temp_kappa` at `max_iter`. Pick `temp_kappa` on the scale of the
 typical uphill `dE_rms2` so the Metropolis test is selective from the start.
+
+Control-point density can decrease with depth: sampling weight per cell is
+`(z_center + z1)^(-ctrl_depth_power)` (0 = uniform, 1 ≈ uniform per log-depth).
+Kernel widths grade from `sigma_scale` (cells) at the top of the core to
+`sigma_scale_deep` at the bottom, interpolated in log-depth over the grid's own
+depth range; equal values give uniform widths.
+
+Frozen cells never receive control points, are never perturbed, and are never
+bound-clamped. Topographic air (tagged as NaN in the loaded model) is always
+frozen. Water is frozen additionally when a mask is active: from
+`bathymetry_file` (written by [`write_bathymetry`](@ref)) if set, otherwise from
+start-model cells with `log10 ρ < water_log10` (NaN disables); a model-derived
+water mask is exported to `bathymetry.dat` in the run directory for reuse.
 """
 Base.@kwdef mutable struct VFSA3DMTConfig
     nchains::Int
@@ -54,7 +77,18 @@ Base.@kwdef mutable struct VFSA3DMTConfig
     # on iterations where iter % model_save_every == 0 (best model always kept)
     model_save_every::Int
     sigma_scale::Float64
+    sigma_scale_deep::Float64
     trunc_sigmas::Float64
+    # ctrl_depth_power: control-point sampling weight ∝ depth^(-p); 0 = uniform
+    ctrl_depth_power::Float64
+    # water_log10: freeze start-model cells below this log10 ρ; NaN = no mask
+    water_log10::Float64
+    # bathymetry_file: build the water mask from this file instead ("" = off)
+    bathymetry_file::String
+    # distortion_mode: :none = current behavior; :full = per-site 2x2 galvanic C
+    distortion_mode::Symbol = :none
+    # distortion_damping: relative damping toward C=I (lambda = a*tr(N)/2); Inf = C≡I
+    distortion_damping::Float64 = 0.01
 end
 
 #---------- internal helpers ----------
@@ -135,19 +169,46 @@ struct RBFMap
 end
 
 """
-    build_rbf_map(m, ix, iy, n_ctrl, rng; sigma_scale=2.0, trunc_sigmas=3.0)
+    build_rbf_map(m, ix, iy, n_ctrl, rng; sigma_scale=2.0, trunc_sigmas=3.0,
+                  sigma_scale_deep=sigma_scale, depth_power=0.0, exclude=nothing)
 
 Randomly pick up to `n_ctrl` control voxels in the core and precompute
-Gaussian-RBF weights for every core voxel.
+Gaussian-RBF weights for every core voxel. Kernel widths (in cells) grade from
+`sigma_scale` at the top of the core to `sigma_scale_deep` at the bottom,
+interpolated per control in log-depth over the grid's own depth range, so the
+profile adapts to any survey without absolute-depth settings; equal values give
+uniform widths. `depth_power` biases control placement shallow and `exclude`
+marks cells that may not receive controls.
 """
 function build_rbf_map(m::WS3DModel, ix::UnitRange{Int}, iy::UnitRange{Int}, n_ctrl::Int, rng::AbstractRNG;
-                       sigma_scale::Float64 = 2.0, trunc_sigmas::Float64 = 3.0)
+                       sigma_scale::Float64 = 2.0, trunc_sigmas::Float64 = 3.0,
+                       sigma_scale_deep::Float64 = sigma_scale,
+                       depth_power::Float64 = 0.0,
+                       exclude::Union{Nothing,AbstractArray{Bool,3}} = nothing)
 
     nx, ny, nz = length(ix), length(iy), m.nz
     N = nx * ny * nz
-    n_sel = min(n_ctrl, N)
+    n_avail = exclude === nothing ? N : N - count(exclude)
+    n_avail > 0 || error("build_rbf_map: every core cell is excluded")
+    n_sel = min(n_ctrl, n_avail)
+    n_sel < n_ctrl && @warn "build_rbf_map: only $n_sel of $n_ctrl controls placed (exclusion)"
 
-    idxs = randperm(rng, N)[1:n_sel]
+    # depth-weighted, mask-aware placement: sampling weight ∝ (z_center + z1)^(-depth_power),
+    # zero in excluded cells; depth_power = 0 with no mask is uniform placement
+    # (weighted sampling without replacement via exponential keys, Efraimidis–Spirakis)
+    zc = m.cz
+    z1 = abs(zc[1]) + eps()
+    keys = Vector{Float64}(undef, N)
+    @inbounds for id in 1:N
+        k = Int(ceil(id / (nx*ny)))
+        rem1 = id - (k-1)*nx*ny
+        j = Int(ceil(rem1 / nx))
+        i = rem1 - (j-1)*nx
+        w = (exclude !== nothing && exclude[i, j, k]) ? 0.0 :
+            (depth_power == 0.0 ? 1.0 : (abs(zc[k]) + z1)^(-depth_power))
+        keys[id] = w > 0 ? rand(rng)^(1.0 / w) : -Inf
+    end
+    idxs = collect(partialsortperm(keys, 1:n_sel; rev=true))
     ci = Vector{Int}(undef, n_sel)
     cj = similar(ci)
     ck = similar(ci)
@@ -164,53 +225,47 @@ function build_rbf_map(m::WS3DModel, ix::UnitRange{Int}, iy::UnitRange{Int}, n_c
         ctrl_at[ci[q], cj[q], ck[q]] = q
     end
 
-    dx_med = median(m.dx)
-    dy_med = median(m.dy)
-    dz_med = median(m.dz)
+    z_top = abs(zc[1])
+    z_bot = abs(zc[nz])
+    denom = log(z_bot + z1) - log(z_top + z1)
+    sig = Vector{Float64}(undef, n_sel)
+    @inbounds for q in 1:n_sel
+        t = denom > 0 ? clamp((log(abs(zc[ck[q]]) + z1) - log(z_top + z1)) / denom, 0.0, 1.0) : 0.0
+        sig[q] = sigma_scale + t * (sigma_scale_deep - sigma_scale)
+    end
 
-    σx = sigma_scale * dx_med
-    σy = sigma_scale * dy_med
-    σz = sigma_scale * dz_med
-
-    rx = ceil(Int, trunc_sigmas * σx / dx_med)
-    ry = ceil(Int, trunc_sigmas * σy / dy_med)
-    rz = ceil(Int, trunc_sigmas * σz / dz_med)
+    cell_ids = [Int[] for _ in 1:N]
+    cell_wts = [Float64[] for _ in 1:N]
+    @inbounds for q in 1:n_sel
+        sq = sig[q]
+        rq = ceil(Int, trunc_sigmas * sq)
+        for kk in max(1, ck[q]-rq):min(nz, ck[q]+rq),
+            jj in max(1, cj[q]-rq):min(ny, cj[q]+rq),
+            ii in max(1, ci[q]-rq):min(nx, ci[q]+rq)
+            r2 = ((ii - ci[q])^2 + (jj - cj[q])^2 + (kk - ck[q])^2) / sq^2
+            if r2 <= trunc_sigmas^2
+                id = ii + (jj-1)*nx + (kk-1)*nx*ny
+                push!(cell_ids[id], q)
+                push!(cell_wts[id], exp(-0.5 * r2))
+            end
+        end
+    end
 
     ptr  = Vector{Int}(undef, N + 1)
     nbrs = Int[];       sizehint!(nbrs, 8 * N)
     wts  = Float64[];   sizehint!(wts,  8 * N)
 
-    row = 1
     ptr[1] = 1
+    row = 1
     @inbounds for k in 1:nz, j in 1:ny, i in 1:nx
-        i1 = max(1, i - rx);  i2 = min(nx, i + rx)
-        j1 = max(1, j - ry);  j2 = min(ny, j + ry)
-        k1 = max(1, k - rz);  k2 = min(nz, k + rz)
-
-        local_ids = Int[]
-        local_wts = Float64[]
-
-        for kk in k1:k2, jj in j1:j2, ii in i1:i2
-            q = ctrl_at[ii, jj, kk]
-            if q == 0; continue; end
-            Δx = (i - ii) * dx_med
-            Δy = (j - jj) * dy_med
-            Δz = (k - kk) * dz_med
-            r2 = (Δx/σx)^2 + (Δy/σy)^2 + (Δz/σz)^2
-            if r2 <= trunc_sigmas^2
-                push!(local_ids, q)
-                push!(local_wts, exp(-0.5 * r2))
-            end
-        end
+        local_ids = cell_ids[row]
+        local_wts = cell_wts[row]
 
         if isempty(local_ids)
             best_q = 1
             best_r2 = typemax(Float64)
             for q in 1:n_sel
-                Δx = (i - ci[q]) * dx_med
-                Δy = (j - cj[q]) * dy_med
-                Δz = (k - ck[q]) * dz_med
-                r2 = (Δx/σx)^2 + (Δy/σy)^2 + (Δz/σz)^2
+                r2 = ((i - ci[q])^2 + (j - cj[q])^2 + (k - ck[q])^2) / sig[q]^2
                 if r2 < best_r2
                     best_r2 = r2; best_q = q
                 end
@@ -313,11 +368,16 @@ function forward_and_misfit!(m::WS3DModel;
     end
     if !ok || !isfile(dpred_abs)
         _cleanup_modem_artifacts!(run_dir)
-        return Inf
+        return Inf, nothing
+    end
+    if cfg.distortion_mode == :full
+        fit = chi2_and_rms_distorted(dobs_abs, dpred_abs; damping=cfg.distortion_damping)
+        _cleanup_modem_artifacts!(run_dir)
+        return fit.rms, fit
     end
     s = chi2_and_rms(dobs_abs, dpred_abs; use_impedance=true, use_tipper=true, components=String[])
     _cleanup_modem_artifacts!(run_dir)
-    return s.rms
+    return s.rms, nothing
 end
 
 #---------- logging ----------
@@ -335,7 +395,11 @@ function _write_trials_header_3d(path::AbstractString; timestamp::String, cfg::V
                     "  ak=", ak,
                     "  max_iter=", cfg.max_iter,
                     "  target_rms=", cfg.target_rms,
-                    "  n_trials=", cfg.n_trials)
+                    "  n_trials=", cfg.n_trials,
+                    "  depth_power=", cfg.ctrl_depth_power,
+                    "  water_log10=", cfg.water_log10,
+                    "  distortion=", cfg.distortion_mode,
+                    "  distortion_damping=", cfg.distortion_damping)
         println(io, repeat("-", 102))
         @printf(io, "%8s %8s %12s %11s %12s %10s %10s %5s %11s %s\n",
                 "Iter","Trial","Temp",
@@ -374,7 +438,11 @@ function _write_iter_header_3d(path::AbstractString; timestamp::String, cfg::VFS
                     "  ak=", ak,
                     "  max_iter=", cfg.max_iter,
                     "  target_rms=", cfg.target_rms,
-                    "  n_trials=", cfg.n_trials)
+                    "  n_trials=", cfg.n_trials,
+                    "  depth_power=", cfg.ctrl_depth_power,
+                    "  water_log10=", cfg.water_log10,
+                    "  distortion=", cfg.distortion_mode,
+                    "  distortion_damping=", cfg.distortion_damping)
         println(io, repeat("-", 88))
         # current accepted state after the iteration, Nacc = accepted trials this iter
         @printf(io, "%8s %12s %11s %11s %6s %s\n",
@@ -441,10 +509,40 @@ function _run_chain_3d(chain_id::Int, start_model_path::String,
     finite_bg = filter(isfinite, background_resistivities)
     background_log10 = median(finite_bg)
 
+    #---------- frozen cells: no controls, no perturbation, no clamp ----------
+    # water is optional (bathymetry_file / water_log10); topographic air is
+    # always frozen — the loader tags it as NaN in v0_core_log10
+    mask = falses(size(v0_core_log10))
+    if !isempty(cfg.bathymetry_file)
+        bathy = read_bathymetry(cfg.bathymetry_file)
+        mask .= water_mask_from_bathymetry(m, bathy)[ix, iy, :]
+    elseif !isnan(cfg.water_log10)
+        mask .= v0_core_log10 .< cfg.water_log10
+        # export the model-derived mask for reuse on future grids
+        if chain_id == 1 && count(mask) > 0
+            bathy = extract_bathymetry(m; water_log10=cfg.water_log10)
+            write_bathymetry(joinpath(results_root, "bathymetry.dat"), bathy;
+                             water_log10=cfg.water_log10)
+        end
+    end
+    n_water = count(mask)
+    air = isnan.(v0_core_log10)          # topographic air above the ground surface
+    mask .|= air
+    n_air = count(air)
+    n_frozen = count(mask)
+
     # build the RBF map
     rbfmap = build_rbf_map(m, ix, iy, cfg.n_ctrl, rng;
-                           sigma_scale=cfg.sigma_scale, trunc_sigmas=cfg.trunc_sigmas)
+                           sigma_scale=cfg.sigma_scale, trunc_sigmas=cfg.trunc_sigmas,
+                           sigma_scale_deep=cfg.sigma_scale_deep,
+                           depth_power=cfg.ctrl_depth_power,
+                           exclude=(n_frozen > 0 ? mask : nothing))
     M = length(rbfmap.ci)
+    if n_frozen > 0 || cfg.ctrl_depth_power != 0.0
+        z_ctrl = [abs(m.cz[k]) for k in rbfmap.ck]
+        @info @sprintf("[chain %02d] mask: %d air + %d water cells frozen; %d controls, median depth %.0f m, %d above 6 km",
+                       chain_id, n_air, n_water, M, median(z_ctrl), count(<(6000.0), z_ctrl))
+    end
 
     v0_ctrl = Vector{Float64}(undef, M)
     @inbounds for t in 1:M
@@ -462,9 +560,9 @@ function _run_chain_3d(chain_id::Int, start_model_path::String,
     embed_core!(m, v0_core_log10, ix, iy)
     smooth_padding_decay_xy!(m, ix, iy, background_log10, cfg.padding_decay_length)
 
-    dp0 = forward_and_misfit!(m; run_dir=chain_dir, model_filename=model0_filename,
-                              dobs_filename=dobs_filename, dpred_filename=dpred0_filename,
-                              origin=origin, rotation=rotation, cfg=cfg)
+    dp0, fit0 = forward_and_misfit!(m; run_dir=chain_dir, model_filename=model0_filename,
+                                    dobs_filename=dobs_filename, dpred_filename=dpred0_filename,
+                                    origin=origin, rotation=rotation, cfg=cfg)
     rms_current = dp0
     best_rms    = rms_current
     T0_chain = cfg.temp_kappa
@@ -473,6 +571,10 @@ function _run_chain_3d(chain_id::Int, start_model_path::String,
     _write_iter_header_3d(iter_log; timestamp=timestamp, cfg=cfg, chain_seed=chain_seed, T0_chain=T0_chain, ak=ak_chain)
     best_model_abs = joinpath(results_root, @sprintf("best_model_chain%02d.rho", chain_id))
     cp(joinpath(chain_dir, model0_filename), best_model_abs; force=true)
+    # per-site distortion of the current best model, refreshed on every new best
+    distortion_abs = joinpath(chain_dir, "distortion_best.txt")
+    fit0 !== nothing && write_distortion_file(distortion_abs, fit0;
+                                              iter=0, rms=dp0, damping=cfg.distortion_damping)
     # filename of the current accepted model, carried forward so the iteration
     # log always names a model even on iterations with no accepted trial
     current_model_rel = model0_filename
@@ -493,6 +595,7 @@ function _run_chain_3d(chain_id::Int, start_model_path::String,
         best_trial_delta_params = similar(delta_params_current)
         best_trial_model_rel = ""
         best_trial_idx = 0
+        best_trial_fit = nothing
 
         for t in 1:cfg.n_trials
             # propose from the iteration-start state, the chain only advances
@@ -503,15 +606,17 @@ function _run_chain_3d(chain_id::Int, start_model_path::String,
 
             apply_rbf_map!(delta_values_buffer, rbfmap, delta_params_trial)
             v_trial = clamp.(v0_core_log10 .+ delta_values_buffer, lo, hi)
+            # frozen water cells: undo kernel bleed-in and bound clamping
+            n_frozen > 0 && (v_trial[mask] .= v0_core_log10[mask])
 
             embed_core!(m, v_trial, ix, iy)
             smooth_padding_decay_xy!(m, ix, iy, background_log10, cfg.padding_decay_length)
 
             model_filename = @sprintf("model_%02d_%03d_%02d.rho", chain_id, k, t)
             dpred_filename = @sprintf("dpred_%02d_%03d_%02d.dat", chain_id, k, t)
-            dp = forward_and_misfit!(m; run_dir=chain_dir, model_filename=model_filename,
-                                     dobs_filename=dobs_filename, dpred_filename=dpred_filename,
-                                     origin=origin, rotation=rotation, cfg=cfg)
+            dp, fit_t = forward_and_misfit!(m; run_dir=chain_dir, model_filename=model_filename,
+                                            dobs_filename=dobs_filename, dpred_filename=dpred_filename,
+                                            origin=origin, rotation=rotation, cfg=cfg)
 
             dE = (dp^2 - rms_iter_start^2) / max(rms_iter_start^2, eps())
             push!(trial_cache, (
@@ -526,6 +631,7 @@ function _run_chain_3d(chain_id::Int, start_model_path::String,
                 best_trial_delta_params .= delta_params_trial
                 best_trial_model_rel = model_filename
                 best_trial_idx = t
+                best_trial_fit = fit_t
             end
         end
 
@@ -544,6 +650,9 @@ function _run_chain_3d(chain_id::Int, start_model_path::String,
             if rms_current < best_rms
                 best_rms = rms_current
                 cp(joinpath(chain_dir, best_trial_model_rel), best_model_abs; force=true)
+                best_trial_fit !== nothing && write_distortion_file(distortion_abs, best_trial_fit;
+                                                                    iter=k, rms=best_rms,
+                                                                    damping=cfg.distortion_damping)
             end
         end
         # backfill the winning trial's metropolis draw into its log row
@@ -628,6 +737,12 @@ Run a 3D VFSA MT inversion. Returns `(best_model_path, iter_log_path)`.
 function VFSA3DMT(start_model_path::AbstractString;
                   dobs_path::AbstractString,
                   cfg::VFSA3DMTConfig)
+    cfg.ctrl_depth_power >= 0 ||
+        error("cfg.ctrl_depth_power must be >= 0, got $(cfg.ctrl_depth_power)")
+    cfg.sigma_scale_deep > 0 ||
+        error("cfg.sigma_scale_deep must be > 0, got $(cfg.sigma_scale_deep)")
+    isempty(cfg.bathymetry_file) || isfile(cfg.bathymetry_file) ||
+        error("cfg.bathymetry_file not found: $(cfg.bathymetry_file)")
     start_model_abs = abspath(start_model_path)
     model_dir = dirname(start_model_abs)
 

--- a/test/TestBathymetry3D.jl
+++ b/test/TestBathymetry3D.jl
@@ -1,0 +1,100 @@
+# Bathymetry extraction / water-mask / depth-weighted RBF placement tests
+# (headless, no solver). Builds a tiny synthetic WS3D model through the file
+# round-trip so grid conventions match load_ws3d_model exactly.
+
+using Random
+
+@testset "Bathymetry and water masks (Bathymetry3D)" begin
+
+    nx, ny, nz = 6, 5, 4
+    dx = fill(1000.0, nx); dy = fill(1000.0, ny)
+    dz = [100.0, 200.0, 400.0, 800.0]        # bottoms at 100, 300, 700, 1500 m
+    A = fill(2.0, nx, ny, nz)
+    # water: columns i=1:2 (all j) wet through layer 2; column (3,1) wet layer 1
+    A[1:2, :, 1:2] .= -0.5
+    A[3, 1, 1] = -0.5
+
+    path = joinpath(mktempdir(), "tiny.ws")
+    write_ws3d_model(path, dx, dy, dz, A)
+    m = load_ws3d_model(path)
+
+    expected = falses(nx, ny, nz)
+    expected[1:2, :, 1:2] .= true
+    expected[3, 1, 1] = true
+
+    #---------- threshold mask ----------
+    mask_thr = water_mask_from_model(m; water_log10=0.5)
+    @test mask_thr == expected
+    @test count(mask_thr) == 21                     # 2x5x2 block + 1 cell
+
+    #---------- bathymetry extraction ----------
+    bathy = extract_bathymetry(m; water_log10=0.5)
+    @test length(bathy.depth) == 11                 # 10 columns at 300 m + 1 at 100 m
+    @test count(==(300.0), bathy.depth) == 10
+    @test count(==(100.0), bathy.depth) == 1
+
+    #---------- file round trip and mask equivalence ----------
+    bpath = joinpath(mktempdir(), "bathy.dat")
+    write_bathymetry(bpath, bathy; water_log10=0.5)
+    bathy2 = read_bathymetry(bpath)
+    @test bathy2.x ≈ bathy.x
+    @test bathy2.y ≈ bathy.y
+    @test bathy2.depth ≈ bathy.depth
+    @test water_mask_from_bathymetry(m, bathy2) == expected
+
+    #---------- rbf placement: exclusion and depth weighting ----------
+    rng = MersenneTwister(7)
+    rbfmap = build_rbf_map(m, 1:nx, 1:ny, 40, rng;
+                           depth_power=1.0, exclude=expected)
+    M = length(rbfmap.ci)
+    @test M == 40
+    @test all(t -> !expected[rbfmap.ci[t], rbfmap.cj[t], rbfmap.ck[t]], 1:M)
+
+    # requesting more controls than non-excluded cells warns and truncates
+    rbfmap_full = @test_logs (:warn, r"only") match_mode=:any build_rbf_map(
+        m, 1:nx, 1:ny, nx*ny*nz, rng; exclude=expected)
+    @test length(rbfmap_full.ci) == nx*ny*nz - 21
+
+    # depth_power = 0, no exclusion: uniform placement still works
+    rbfmap_u = build_rbf_map(m, 1:nx, 1:ny, 25, rng)
+    @test length(rbfmap_u.ci) == 25
+end
+
+@testset "Depth-scaled RBF widths" begin
+    nx, ny, nz = 8, 7, 6
+    dx = fill(1000.0, nx); dy = fill(1000.0, ny)
+    dz = [50.0, 100.0, 300.0, 900.0, 2700.0, 8100.0]
+    A = fill(2.0, nx, ny, nz)
+    path = joinpath(mktempdir(), "tiny2.ws")
+    write_ws3d_model(path, dx, dy, dz, A)
+    m = load_ws3d_model(path)
+
+    keep = trues(nx, ny, nz)
+    keep[4, 4, 1] = false
+    keep[4, 4, 6] = false
+    rng = MersenneTwister(11)
+    r = build_rbf_map(m, 1:nx, 1:ny, 2, rng;
+                      sigma_scale=1.0, sigma_scale_deep=3.0, exclude=keep)
+    @test length(r.ci) == 2
+    q_top = findfirst(==(1), r.ck)
+    q_bot = findfirst(==(6), r.ck)
+    @test q_top !== nothing && q_bot !== nothing
+
+    N = nx * ny * nz
+    for row in 1:N
+        @test sum(r.wts[r.ptr[row]:r.ptr[row+1]-1]) ≈ 1.0
+    end
+
+    rowid(i, j, k) = i + (j - 1) * nx + (k - 1) * nx * ny
+    wof(row, q) = begin
+        p = r.ptr[row]:r.ptr[row+1]-1
+        t = findfirst(==(q), r.nbrs[p])
+        t === nothing ? 0.0 : r.wts[p][t]
+    end
+    @test wof(rowid(4, 4, 4), q_bot) > 0.9
+    @test wof(rowid(4, 4, 2), q_top) > wof(rowid(4, 4, 2), q_bot)
+
+    dv = zeros(nx, ny, nz)
+    apply_rbf_map!(dv, r, fill(3.7, 2))
+    @test all(x -> isapprox(x, 3.7; atol=1e-12), dv)
+end

--- a/test/TestDistortion3D.jl
+++ b/test/TestDistortion3D.jl
@@ -1,0 +1,128 @@
+@testset "3D galvanic distortion" begin
+
+    # small synthetic dataset, 3 periods x 2 sites, full impedance + tipper
+    function _make_pred_data()
+        d = make_nan_data()
+        d.T = [0.01, 1.0, 100.0]
+        d.f = 1.0 ./ d.T
+        d.nf = 3
+        d.site = ["S01", "S02"]
+        d.ns = 2
+        d.loc = [60.0 24.0 100.0; 61.0 25.0 200.0]
+        d.x = [1000.0, 2000.0]
+        d.y = [-500.0, 500.0]
+        d.z = [100.0, 200.0]
+        d.responses = ["ZXX", "ZXY", "ZYX", "ZYY", "TX", "TY"]
+        d.nr = 6
+        d.zrot = zeros(d.nf, d.ns)
+        d.trot = d.zrot
+        d.origin = [60.5, 24.5, 0.0]
+        d.Z = Array{ComplexF64,3}(undef, d.nf, 4, d.ns)
+        d.Zerr = Array{ComplexF64,3}(undef, d.nf, 4, d.ns)
+        d.tip = Array{ComplexF64,3}(undef, d.nf, 2, d.ns)
+        d.tiperr = Array{ComplexF64,3}(undef, d.nf, 2, d.ns)
+        for is in 1:d.ns, ip in 1:d.nf
+            for ic in 1:4
+                d.Z[ip, ic, is] = ComplexF64(ip + 0.1 * ic + 0.01 * is, -(ip + 0.2 * ic))
+                d.Zerr[ip, ic, is] = ComplexF64(0.05 * ip, 0.0)
+            end
+            for ic in 1:2
+                d.tip[ip, ic, is] = ComplexF64(0.3 * ip + 0.01 * ic, 0.1 * is)
+                d.tiperr[ip, ic, is] = ComplexF64(0.02 * ip, 0.0)
+            end
+        end
+        d.ρ, d.φ, d.ρerr, d.φerr = calc_rho_pha(d.Z, d.Zerr, d.T)
+        return d
+    end
+
+    # apply a per-site real 2x2 distortion to the impedance rows
+    function _distort!(d, Cs)
+        for is in 1:d.ns
+            c11, c12, c21, c22 = Cs[is]
+            for ip in 1:d.nf
+                zxx, zxy, zyx, zyy = d.Z[ip, 1, is], d.Z[ip, 2, is], d.Z[ip, 3, is], d.Z[ip, 4, is]
+                d.Z[ip, 1, is] = c11 * zxx + c12 * zyx
+                d.Z[ip, 2, is] = c11 * zxy + c12 * zyy
+                d.Z[ip, 3, is] = c21 * zxx + c22 * zyx
+                d.Z[ip, 4, is] = c21 * zxy + c22 * zyy
+            end
+        end
+        return d
+    end
+
+    C_true = [(1.2, 0.3, -0.1, 0.8), (0.9, -0.2, 0.15, 1.1)]
+
+    mktempdir() do dir
+        pred_file = joinpath(dir, "dpred.dat")
+        obs_file = joinpath(dir, "dobs.dat")
+        dp = _make_pred_data()
+        write_data_modem(pred_file, dp)
+        dobs = _distort!(_make_pred_data(), C_true)
+        write_data_modem(obs_file, dobs)
+
+        @testset "known C recovery" begin
+            fit = chi2_and_rms_distorted(obs_file, pred_file; damping=1e-8)
+            @test isa(fit, DistortionFit)
+            for is in 1:2
+                c11, c12, c21, c22 = C_true[is]
+                @test fit.C[1, 1, is] ≈ c11 atol = 1e-3
+                @test fit.C[1, 2, is] ≈ c12 atol = 1e-3
+                @test fit.C[2, 1, is] ≈ c21 atol = 1e-3
+                @test fit.C[2, 2, is] ≈ c22 atol = 1e-3
+            end
+            # impedance residuals vanish after correction; only tipper misfit remains (zero here)
+            @test fit.rms < 1e-4
+        end
+
+        @testset "damping=Inf reproduces chi2_and_rms" begin
+            fit = chi2_and_rms_distorted(obs_file, pred_file; damping=Inf)
+            @test all(fit.C[1, 1, :] .== 1.0)
+            @test all(fit.C[2, 2, :] .== 1.0)
+            @test all(fit.C[1, 2, :] .== 0.0)
+            @test all(fit.C[2, 1, :] .== 0.0)
+            @test fit.penalty == 0.0
+            s = chi2_and_rms(obs_file, pred_file)
+            @test fit.rms == s.rms
+            @test fit.χ² == s.χ²
+        end
+
+        @testset "finite damping lowers misfit" begin
+            fit_inf = chi2_and_rms_distorted(obs_file, pred_file; damping=Inf)
+            fit_low = chi2_and_rms_distorted(obs_file, pred_file; damping=0.01)
+            @test fit_low.rms <= fit_inf.rms
+            @test fit_low.penalty >= 0.0
+        end
+
+        @testset "diagnostics file" begin
+            fit = chi2_and_rms_distorted(obs_file, pred_file; damping=1e-8)
+            out = joinpath(dir, "distortion_best.txt")
+            @test write_distortion_file(out, fit; iter=7, rms=fit.rms, damping=1e-8) == out
+            lines = readlines(out)
+            @test any(l -> occursin("iter=7", l), lines)
+            body = filter(l -> !startswith(l, "#"), lines)
+            @test length(body) == 2
+            # sorted by ||C-I||_F descending: site 1 (C further from I) first
+            @test startswith(body[1], "S01")
+        end
+    end
+
+    @testset "nan handling" begin
+        mktempdir() do dir
+            dp = _make_pred_data()
+            dobs = _distort!(_make_pred_data(), C_true)
+            # knock out one obs entry and one pred entry; site 2 impedance all missing
+            dobs.Z[1, 2, 1] = ComplexF64(NaN, NaN)
+            dp.Z[2, 3, 1] = ComplexF64(NaN, NaN)
+            dobs.Z[:, :, 2] .= ComplexF64(NaN, NaN)
+            pred_file = joinpath(dir, "dpred.dat")
+            obs_file = joinpath(dir, "dobs.dat")
+            write_data_modem(pred_file, dp)
+            write_data_modem(obs_file, dobs)
+            fit = chi2_and_rms_distorted(obs_file, pred_file; damping=1e-8)
+            @test all(isfinite, fit.C[:, :, 1])
+            # all-nan site falls back to identity
+            @test fit.C[:, :, 2] == [1.0 0.0; 0.0 1.0]
+            @test isfinite(fit.rms)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,9 @@ include(joinpath(dirname(@__DIR__), "helpers", "benchmarks_2d.jl"))
 @testset "MTGeophysics.jl Tests" begin
 
     include(joinpath(@__DIR__, "TestIO3D.jl"))
+    include(joinpath(@__DIR__, "TestDistortion3D.jl"))
     include(joinpath(@__DIR__, "TestCore3D.jl"))
+    include(joinpath(@__DIR__, "TestBathymetry3D.jl"))
     include(joinpath(@__DIR__, "TestShapefileOverlay.jl"))
     include(joinpath(@__DIR__, "TestForward1D.jl"))
     include(joinpath(@__DIR__, "TestForward2D.jl"))


### PR DESCRIPTION
Cacadia inversion can take bathymetry file as input and makes sure that no RBF points are allocated into that region. (2) make_mesh function derives topography from a geotiff file and adjusts model center so that the higestest sites has z=0. Model center is negative to accomodate model area higer than the highest elevation site (3) RBF-centers are now distributed adaptively (more on shallower cells and it can be controlled with a free parameter) (4) An experimental version of VFSA extension that deals with galventic distorted sites..(not tested)