### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: 'MTGeophysics.jl: A software repository for magnetotelluric research and applications'
+type: software
+authors:
+- given-names: Pankaj K
+  family-names: Mishra
+  orcid: https://orcid.org/0000-0003-4907-4724
+repository-code: https://github.com/JuliaGeophysics/MTGeophysics.jl
+license: MIT


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and tools can pick up machine-readable citation metadata.

Author names and ORCIDs are taken from `paper.md`, and the licence from the LICENSE file. Validated with `cffconvert --validate` against schema 1.2.0.

Please check the given-name/family-name split is right for each author, since I derived it from the single `name` field in the paper.